### PR TITLE
feat(collect-garbage): run `crictl rmi --prune` inside kind cluster n…

### DIFF
--- a/collect-garbage.sh
+++ b/collect-garbage.sh
@@ -52,5 +52,14 @@ docker image prune -fa;
 echo "Orphaned docker containers and images collected."
 
 echo  ================================================================
+echo "Cleaning orphaned images inside kind cluster nodes..."
+echo  ================================================================
+
+for nodeName in $(kind get nodes)
+do
+  docker exec "${nodeName}" bash -c "crictl rmi --prune";
+done;
+
+echo  ================================================================
 
 echo "Cleanup Done! Thanks."


### PR DESCRIPTION
…odes